### PR TITLE
Map Docker labels to appc annotations.

### DIFF
--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -271,6 +271,10 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 			genManifest.App = app
 		}
+
+		for k, v := range dockerConfig.Labels {
+			addAnno(k, v)
+		}
 	}
 
 	if layerData.Parent != "" {

--- a/lib/internal/types/docker_types.go
+++ b/lib/internal/types/docker_types.go
@@ -62,6 +62,7 @@ type DockerImageConfig struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	Labels          map[string]string
 }
 
 // DockerAuthConfigOld represents the deprecated ~/.dockercfg auth


### PR DESCRIPTION
None of the tests currently investigate the accuracy of the manifest, so I did
not add a test to validate that the labels were accurately ported. It does,
however, seem straightforward. If the docker labels in config JSON hashes
aren't ignored, then they become annotations in the resulting ACI manifest.

I did at least confirm that this works as expected. :)
